### PR TITLE
🐛 Fixing the render_pj_minimap without the pj.rot and with the radians.

### DIFF
--- a/srcs/routine/minimap_bonus/minimap_pj_bonus.c
+++ b/srcs/routine/minimap_bonus/minimap_pj_bonus.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minimap_pj_bonus.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: user42 <user42@student.42.fr>              +#+  +:+       +#+        */
+/*   By: ldutriez <ldutriez@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/04 18:28:28 by amarini-          #+#    #+#             */
-/*   Updated: 2022/06/05 14:51:11 by user42           ###   ########.fr       */
+/*   Updated: 2022/06/06 17:27:57 by ldutriez         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,8 @@ void	render_pj_minimap(t_system *sys, t_int2 map_start, int pxl_unit)
 	pos.x = (map_start.x + (sys->pj.pos.x * pxl_unit)) - (pxl_unit - size) / 2;
 	draw_circle(sys, color, pos, size);
 	pos = make_int2(pos.y + size / 2, pos.x + size / 2);
-	dir.y = pos.y - (pxl_unit * sinf(sys->pj.rot * (M_PI / 180)));
-	dir.x = pos.x - (pxl_unit * cosf(sys->pj.rot * (M_PI / 180)));
+	dir.y = sys->pj.dir.y * 4 * pxl_unit + pos.y;
+	dir.x = sys->pj.dir.x * 4 * pxl_unit + pos.x;
 	color = make_color(255, 0, 255, 0);
 	draw_line(sys, pos, dir, color);
 }


### PR DESCRIPTION
In this function you can tweak the longer of the direction by changing the '* 4' in the calcul.